### PR TITLE
Fix location delegate leak; set default timeout for single location update.

### DIFF
--- a/Classes/MMPReactiveCoreLocation.h
+++ b/Classes/MMPReactiveCoreLocation.h
@@ -28,6 +28,7 @@
 #import <ReactiveCocoa/ReactiveCocoa.h>
 
 #define MMPRCL_LOCATION_AGE_LIMIT_DEFAULT 5.0
+#define MMPRCL_LOCATION_TIMEOUT_DEFAULT -1
 
 /**
  *  Error domain for errors produced by the library.
@@ -67,6 +68,12 @@ typedef NSInteger MMPRCLLocationUpdateType;
  *  See CLLocationManager documentation for more information on this property.
  */
 @property(assign, nonatomic) CLLocationAccuracy desiredAccuracy;
+
+/**
+ *  How long will manager wait for location update. Default to infinite(-1).
+ *  Measured in seconds.
+ */
+@property(assign, nonatomic) NSTimeInterval defaultTimeout;
 
 /**
  *  Default value for activityType to be set to default CLLocationManager.

--- a/Classes/MMPReactiveCoreLocation.m
+++ b/Classes/MMPReactiveCoreLocation.m
@@ -81,6 +81,7 @@ const NSInteger MMPRCLSignalErrorServiceUnavailable = 1;
         _activityType = CLActivityTypeOther;
         _locationUpdateType = MMPRCLLocationUpdateTypeStandard;
         _locationAgeLimit = MMPRCL_LOCATION_AGE_LIMIT_DEFAULT;
+        _defaultTimeout = MMPRCL_LOCATION_TIMEOUT_DEFAULT;
         
         _lastKnownLocation = nil;
         _defaultLocationManager = [[CLLocationManager alloc] init];
@@ -191,7 +192,7 @@ const NSInteger MMPRCLSignalErrorServiceUnavailable = 1;
                                                                activityType:_activityType
                                                          locationUpdateType:MMPRCLLocationUpdateTypeStandard
                                                            locationAgeLimit:_locationAgeLimit
-                                                                    timeout:-1.0];
+                                                                    timeout:self.defaultTimeout];
 }
 
 - (RACSignal *)singleLocationSignalWithAccuracy:(CLLocationAccuracy)desiredAccuracy
@@ -202,7 +203,7 @@ const NSInteger MMPRCLSignalErrorServiceUnavailable = 1;
                                                                activityType:_activityType
                                                          locationUpdateType:MMPRCLLocationUpdateTypeStandard
                                                            locationAgeLimit:_locationAgeLimit
-                                                                    timeout:-1.0];
+                                                                    timeout:self.defaultTimeout];
 }
 
 - (RACSignal *)singleLocationSignalWithAccuracy:(CLLocationAccuracy)desiredAccuracy timeout:(NSTimeInterval)timeout
@@ -260,6 +261,8 @@ const NSInteger MMPRCLSignalErrorServiceUnavailable = 1;
             } else {
                 NSLog(@"[WARN] Unknown location update type: %ld, not doing anything.", (long)locationUpdateType);
             }
+            
+            locationManager.delegate = nil; // fix delegate leak bug
             
             [self.singleSignalDelegates removeObject:delegate];
             


### PR DESCRIPTION
CLLocationManager often gives bad access on its delegate if delegate is not set to nil.
Default timeout is just useful thing to have.
